### PR TITLE
Fix the tiles in list view

### DIFF
--- a/components/ArticleTile/articleTile.module.scss
+++ b/components/ArticleTile/articleTile.module.scss
@@ -6,11 +6,10 @@
   background: #fff;
   box-shadow: 1px 1px 6px 1px var(--gray-shadow);
   border-radius: 3px;
-  min-height: 259px;
-  overflow-wrap: break-word;
-  height: 100%;
   display: grid;
   grid-template-rows: auto auto 1fr;
+  word-break: break-word;
+  height: 100%;
 
   @media screen and (min-width: 45em) {
     padding: 2rem;


### PR DESCRIPTION
Turns out, the `overflow-wrap: break-word;` causes the tiles to have a minimum width which doesn't allow for further shrinking. I've needed to use the `word-break: break-word;` (which's equivalent to `overflow-wrap: anywhere`, but better supported) and the issue disappears.