### PR TITLE
fix: Cron schedule wewnątrz workflow'u update-blogs.yml

### DIFF
--- a/.github/workflows/update-blogs.yml
+++ b/.github/workflows/update-blogs.yml
@@ -1,7 +1,7 @@
 name: Update Blogs
 on:
   schedule:
-    - cron: '* 0 * * *' # codziennie o północy
+    - cron: '0 0 * * *' # codziennie o północy
 jobs:
   cron:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Wcześniejszy cron schedule był błędny - `* 0 * * *` - oznaczłoby to że zadanie uruchamia się o każdej minucie po godzinie 0