### PR TITLE
feat: Endpoint do pobierania blogów dla adminów

### DIFF
--- a/api-helpers/api-hofs.ts
+++ b/api-helpers/api-hofs.ts
@@ -91,14 +91,14 @@ export const withAsync = (
   };
 };
 
-export function withAuth<R extends NextApiRequest>(role: UserRole) {
+export function withAuth<R extends NextApiRequest>(role?: UserRole) {
   return (handler: (req: R, res: NextApiResponse) => unknown) => async (
     req: R,
     res: NextApiResponse,
   ) => {
     const session = await getSession({ req });
 
-    if (!session || session.user.role !== role) {
+    if (!session || (role && session.user.role !== role)) {
       throw Boom.unauthorized();
     }
 

--- a/components/AdminPanel/AdminPanel.tsx
+++ b/components/AdminPanel/AdminPanel.tsx
@@ -19,7 +19,7 @@ export const AdminPanel = () => {
   }
 
   if (session?.user.role === 'ADMIN') {
-    return <section></section>; // @to-do admin-panel
+    return <section>admin panel</section>; // @to-do admin-panel
   }
 
   return (

--- a/pages/api/blogs/index.ts
+++ b/pages/api/blogs/index.ts
@@ -1,3 +1,4 @@
+import Boom from '@hapi/boom';
 import { boolean, object } from 'yup';
 
 import { withAsync, withValidation, withAuth } from '../../../api-helpers/api-hofs';
@@ -10,6 +11,10 @@ export default withAsync(
         isPublic: boolean().optional(),
       }).optional(),
     })(async (req) => {
+      if (req.method !== 'GET') {
+        throw Boom.notFound();
+      }
+
       try {
         const prisma = await openConnection();
 
@@ -20,7 +25,7 @@ export default withAsync(
         });
 
         return {
-          blogs,
+          data: blogs,
         };
       } finally {
         await closeConnection();

--- a/pages/api/blogs/index.ts
+++ b/pages/api/blogs/index.ts
@@ -1,0 +1,30 @@
+import { boolean, object } from 'yup';
+
+import { withAsync, withValidation, withAuth } from '../../../api-helpers/api-hofs';
+import { closeConnection, openConnection } from '../../../api-helpers/db';
+
+export default withAsync(
+  withAuth('ADMIN')(
+    withValidation({
+      query: object({
+        isPublic: boolean().optional(),
+      }).optional(),
+    })(async (req) => {
+      try {
+        const prisma = await openConnection();
+
+        const blogs = await prisma.blog.findMany({
+          where: {
+            isPublic: req.query.isPublic,
+          },
+        });
+
+        return {
+          blogs,
+        };
+      } finally {
+        await closeConnection();
+      }
+    }),
+  ),
+);


### PR DESCRIPTION
Resolves #49 

- Endpoint `/api/blogs`, akceptujący `isPublic` w query
- Funkcja withAuth pozwalająca na zabezpieczanie API Routes