### PR TITLE
fix: tekst w buttonach łamie się na mobile

### DIFF
--- a/components/ArticleTile/ArticleTile.tsx
+++ b/components/ArticleTile/ArticleTile.tsx
@@ -40,7 +40,7 @@ export const ArticleTile = ({
             className={style.favicon}
             alt=""
           />
-          {blogName}{' '}
+          <span className={style.blogName}>{blogName}&nbsp;</span>
           <time className={style.articleDate} dateTime={dateTime}>
             {readableDate}
           </time>

--- a/components/ArticleTile/articleTile.module.scss
+++ b/components/ArticleTile/articleTile.module.scss
@@ -46,12 +46,24 @@
   vertical-align: top;
 }
 
+.blogName {
+  display: inline-block;
+  margin-bottom: 0.5rem;
+
+  @media screen and (min-width: 24em) {
+    margin-bottom: 0;
+  }
+}
+
 .articleDate {
   font-weight: 400;
   display: inline-block;
   color: var(--gray-text);
-  &::before {
-    content: '| ';
+
+  @media screen and (min-width: 24em) {
+    &::before {
+      content: '| ';
+    }
   }
 }
 
@@ -81,7 +93,11 @@
 .footerLink {
   text-transform: uppercase;
   font-weight: 700;
-  font-size: 1.2em;
+  font-size: 1em;
+
+  @media screen and (min-width: 45em) {
+    font-size: 1.2em;
+  }
 }
 
 .icon {

--- a/components/Button/button.module.scss
+++ b/components/Button/button.module.scss
@@ -13,6 +13,10 @@
   cursor: pointer;
   font-size: 1em;
 
+  @media screen and (min-width: 45em) {
+    font-size: 1.2em;
+  }
+
   &:hover {
     color: #fff;
     background-color: var(--brand-color-main);

--- a/components/Button/button.module.scss
+++ b/components/Button/button.module.scss
@@ -11,7 +11,7 @@
   text-transform: uppercase;
   font-weight: 700;
   cursor: pointer;
-  font-size: 1.2em;
+  font-size: 1em;
 
   &:hover {
     color: #fff;


### PR DESCRIPTION
Heja, poprawiłem ten za duzy tekst na mobile i przy okazji naprawiłem też brzydko łamiącą się datę posta na mobile. 
Efekty na poniższym screenie.

![Polski Frontend – siatka artykułów z polskich blogów frontendowych 2021-01-10 18-13-21](https://user-images.githubusercontent.com/27632432/104130261-ff062480-536f-11eb-84e0-a9ef24c00db5.png)

Na desktopie jest tak jak było:
![Polski Frontend – siatka artykułów z polskich blogów frontendowych 2021-01-10 18-18-15](https://user-images.githubusercontent.com/27632432/104130308-3e347580-5370-11eb-814d-e920225c1f67.png)


<!-- -->

Resolves #69 <!-- Tutaj wpisz numer issue -->
