### PR TITLE
fix: naprawa skalowania loga w headerze

### DIFF
--- a/components/MainHeader/MainHeader.tsx
+++ b/components/MainHeader/MainHeader.tsx
@@ -9,7 +9,14 @@ export const MainHeader = () => {
       <Link href="/" title="Przejdź na stronę główną" className={Styles.headerLink}>
         <h1 className={Styles.title}>
           <span className="sr-only">Polski frontend</span>
-          <Image src="/logo.svg" alt="" width={480} height={171} />
+          <Image
+            src="/logo.svg"
+            alt=""
+            width={480}
+            height={171}
+            priority
+            className={Styles.headerLogo}
+          />
         </h1>
       </Link>
     </section>

--- a/components/MainHeader/mainHeader.module.scss
+++ b/components/MainHeader/mainHeader.module.scss
@@ -13,3 +13,7 @@
   padding: 0;
   margin: 0 auto;
 }
+
+.headerLogo {
+  height: auto;
+}


### PR DESCRIPTION
Rozwiązuje problem oisany w #193 

### Przed:
![przed](https://user-images.githubusercontent.com/27455716/212733430-4db58cf3-f770-49c2-9207-d120b7592b5e.png)
### Po:
![po](https://user-images.githubusercontent.com/27455716/212733464-1d337428-8924-49fc-a17f-aa5dbcaa9716.png)
